### PR TITLE
[UPDATE] user attribute index with precondition check

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-14.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-14.0.0.xml
@@ -104,6 +104,14 @@
 
     <changeSet author="keycloak" id="KEYCLOAK-17267-add-index-to-user-attributes">
         <validCheckSum>7:1a7f28ff8d9e53aeb879d76ea3d9341a</validCheckSum>
+
+        <!-- Precondition to ensure the index doesn't already exist -->
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="IDX_USER_ATTRIBUTE_NAME" tableName="USER_ATTRIBUTE"/>
+            </not>
+        </preConditions>
+
         <createIndex indexName="IDX_USER_ATTRIBUTE_NAME" tableName="USER_ATTRIBUTE">
             <column name="NAME" type="VARCHAR(255)"/>
             <column name="VALUE" type="VARCHAR(255)"/>


### PR DESCRIPTION

jira link : https://atlanhq.atlassian.net/browse/ATH-1145

description : Add precondition on user attribute index creation in keycloak to ensure the index doesn't already exist